### PR TITLE
Rewrite proxify using Symbol and constant object handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-state-tree",
-  "version": "1.0.0-alpha1",
+  "version": "1.0.0-alpha3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3391,7 +3391,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -3474,8 +3473,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,13 @@
 		"type": "git",
 		"url": "git+https://github.com/christianalfoni/proxy-state-tree.git"
 	},
-	"keywords": [ "state", "proxy", "mobx", "vue", "store" ],
+	"keywords": [
+		"state",
+		"proxy",
+		"mobx",
+		"vue",
+		"store"
+	],
 	"author": "Christian Alfoni",
 	"license": "MIT",
 	"bugs": {
@@ -38,5 +44,8 @@
 		"jest": "^23.1.0",
 		"prettier": "^1.13.5",
 		"rollup": "^0.60.7"
+	},
+	"dependencies": {
+		"is-plain-object": "^2.0.4"
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import proxify from './proxify';
+import proxify, { IS_PROXY } from './proxify';
 
 class ProxyStateTree {
 	constructor(state) {
@@ -52,24 +52,27 @@ class ProxyStateTree {
 	}
 	addMutationListener(initialPaths, cb) {
 		const pathDependencies = this.pathDependencies;
-		let currentStringPaths = initialPaths.map((path) => path.join('.'));
+		let currentStringPaths = initialPaths.map(path => path.join('.'));
 
 		for (let index in currentStringPaths) {
 			const currentStringPath = currentStringPaths[index];
 			pathDependencies[currentStringPath] = pathDependencies[currentStringPath]
 				? pathDependencies[currentStringPath].concat(cb)
-				: [ cb ];
+				: [cb];
 		}
 
 		return {
 			update(newPaths) {
-				const newStringPaths = newPaths.map((path) => path.join('.'));
+				const newStringPaths = newPaths.map(path => path.join('.'));
 
 				for (let index in currentStringPaths) {
 					const currentStringPath = currentStringPaths[index];
 
 					if (newStringPaths.indexOf(currentStringPath) === -1) {
-						pathDependencies[currentStringPath].splice(pathDependencies[currentStringPath].indexOf(cb), 1);
+						pathDependencies[currentStringPath].splice(
+							pathDependencies[currentStringPath].indexOf(cb),
+							1
+						);
 					}
 				}
 
@@ -79,7 +82,7 @@ class ProxyStateTree {
 					if (currentStringPaths.indexOf(newStringPath) === -1) {
 						pathDependencies[newStringPath] = pathDependencies[newStringPath]
 							? pathDependencies[newStringPath].concat(cb)
-							: [ cb ];
+							: [cb];
 					}
 				}
 
@@ -89,7 +92,10 @@ class ProxyStateTree {
 				for (let index in currentStringPaths) {
 					const currentStringPath = currentStringPaths[index];
 
-					pathDependencies[currentStringPath].splice(pathDependencies[currentStringPath].indexOf(cb), 1);
+					pathDependencies[currentStringPath].splice(
+						pathDependencies[currentStringPath].indexOf(cb),
+						1
+					);
 
 					if (!pathDependencies[currentStringPath].length) {
 						delete pathDependencies[currentStringPath];
@@ -100,4 +106,5 @@ class ProxyStateTree {
 	}
 }
 
+export { IS_PROXY };
 export default ProxyStateTree;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,4 +1,4 @@
-import ProxyStateTree from './';
+import ProxyStateTree, { IS_PROXY } from './';
 
 describe('CREATION', () => {
 	test('should create a ProxyStateTree instance', () => {
@@ -11,7 +11,7 @@ describe('CREATION', () => {
 		const state = {};
 		const tree = new ProxyStateTree(state);
 
-		expect(tree.get().__is_proxy).toBeTruthy();
+		expect(tree.get()[IS_PROXY]).toBeTruthy();
 	});
 
 	test('should not create nested proxies when initialized', () => {
@@ -20,7 +20,7 @@ describe('CREATION', () => {
 		};
 		new ProxyStateTree(state); // eslint-disable-line
 
-		expect(state.foo.__is_proxy).not.toBeTruthy();
+		expect(state.foo[IS_PROXY]).not.toBeTruthy();
 	});
 });
 
@@ -32,7 +32,7 @@ describe('OBJECTS', () => {
 			};
 			const tree = new ProxyStateTree(state);
 			tree.get().foo; // eslint-disable-line
-			expect(state.foo.__is_proxy).toBeTruthy();
+			expect(state.foo[IS_PROXY]).toBeTruthy();
 		});
 		test('should access properties', () => {
 			const state = {
@@ -53,7 +53,7 @@ describe('OBJECTS', () => {
 			tree.startPathsTracking();
 			expect(tree.get().foo.bar).toBe('baz');
 			const paths = tree.stopPathsTracking();
-			expect(paths).toEqual([ [ 'foo' ], [ 'foo', 'bar' ] ]);
+			expect(paths).toEqual([['foo'], ['foo', 'bar']]);
 		});
 	});
 	describe('MUTATIONS', () => {
@@ -77,8 +77,8 @@ describe('OBJECTS', () => {
 			expect(mutations).toEqual([
 				{
 					method: 'set',
-					path: [ 'foo' ],
-					args: [ 'bar2' ]
+					path: ['foo'],
+					args: ['bar2']
 				}
 			]);
 			expect(tree.get().foo).toBe('bar2');
@@ -94,7 +94,7 @@ describe('OBJECTS', () => {
 			expect(mutations).toEqual([
 				{
 					method: 'unset',
-					path: [ 'foo' ],
+					path: ['foo'],
 					args: []
 				}
 			]);
@@ -111,24 +111,24 @@ describe('ARRAYS', () => {
 			};
 			const tree = new ProxyStateTree(state);
 			tree.get().foo; // eslint-disable-line
-			expect(state.foo.__is_proxy).toBeTruthy();
+			expect(state.foo[IS_PROXY]).toBeTruthy();
 		});
 		test('should access properties', () => {
 			const state = {
-				foo: [ 'bar' ]
+				foo: ['bar']
 			};
 			const tree = new ProxyStateTree(state);
 			expect(tree.get().foo[0]).toBe('bar');
 		});
 		test('should track access properties', () => {
 			const state = {
-				foo: [ 'bar' ]
+				foo: ['bar']
 			};
 			const tree = new ProxyStateTree(state);
 			tree.startPathsTracking();
 			expect(tree.get().foo[0]).toBe('bar');
 			const paths = tree.stopPathsTracking();
-			expect(paths).toEqual([ [ 'foo' ], [ 'foo', '0' ] ]);
+			expect(paths).toEqual([['foo'], ['foo', '0']]);
 		});
 	});
 	describe('MUTATIONS', () => {
@@ -152,8 +152,8 @@ describe('ARRAYS', () => {
 			expect(mutations).toEqual([
 				{
 					method: 'push',
-					path: [ 'foo' ],
-					args: [ 'bar' ]
+					path: ['foo'],
+					args: ['bar']
 				}
 			]);
 
@@ -162,7 +162,7 @@ describe('ARRAYS', () => {
 		});
 		test('should track POP mutations', () => {
 			const state = {
-				foo: [ 'foo' ]
+				foo: ['foo']
 			};
 			const tree = new ProxyStateTree(state);
 			tree.startMutationTracking();
@@ -171,7 +171,7 @@ describe('ARRAYS', () => {
 			expect(mutations).toEqual([
 				{
 					method: 'pop',
-					path: [ 'foo' ],
+					path: ['foo'],
 					args: []
 				}
 			]);
@@ -180,7 +180,7 @@ describe('ARRAYS', () => {
 		});
 		test('should track POP mutations', () => {
 			const state = {
-				foo: [ 'foo' ]
+				foo: ['foo']
 			};
 			const tree = new ProxyStateTree(state);
 			tree.startMutationTracking();
@@ -189,7 +189,7 @@ describe('ARRAYS', () => {
 			expect(mutations).toEqual([
 				{
 					method: 'shift',
-					path: [ 'foo' ],
+					path: ['foo'],
 					args: []
 				}
 			]);
@@ -207,8 +207,8 @@ describe('ARRAYS', () => {
 			expect(mutations).toEqual([
 				{
 					method: 'unshift',
-					path: [ 'foo' ],
-					args: [ 'foo' ]
+					path: ['foo'],
+					args: ['foo']
 				}
 			]);
 
@@ -216,7 +216,7 @@ describe('ARRAYS', () => {
 		});
 		test('should track SPLICE mutations', () => {
 			const state = {
-				foo: [ 'foo' ]
+				foo: ['foo']
 			};
 			const tree = new ProxyStateTree(state);
 			tree.startMutationTracking();
@@ -225,8 +225,8 @@ describe('ARRAYS', () => {
 			expect(mutations).toEqual([
 				{
 					method: 'splice',
-					path: [ 'foo' ],
-					args: [ 0, 1, 'bar' ]
+					path: ['foo'],
+					args: [0, 1, 'bar']
 				}
 			]);
 
@@ -248,7 +248,7 @@ describe('FUNCTIONS', () => {
 		const state = {
 			foo: (proxyStateTree, path) => {
 				expect(proxyStateTree).toBe(tree);
-				expect(path).toEqual([ 'foo' ]);
+				expect(path).toEqual(['foo']);
 
 				return 'bar';
 			}

--- a/src/proxify.js
+++ b/src/proxify.js
@@ -1,109 +1,120 @@
-const isPlainObject = require("is-plain-object");
+import isPlainObject from 'is-plain-object';
 
-const IS_PROXY = "__is_proxy";
+const IS_PROXY = Symbol('IS_PROXY');
+const PROXY_STATE = Symbol('PROXY_STATE');
 
-function proxifyObject(proxyStateTree, obj, path, paths, mutations) {
-  return new Proxy(obj, {
-    get(target, prop) {
-      if (prop === IS_PROXY) {
-        return true;
-      }
-
-      const value = target[prop];
-      const nestedPath = path.concat(prop);
-
-      if (proxyStateTree.isTrackingPaths) {
-        proxyStateTree.paths.push(nestedPath);
-      }
-
-      if (typeof value === "function") {
-        return value(proxyStateTree, nestedPath);
-      }
-
-      target[prop] = proxify(proxyStateTree, value, nestedPath);
-
-      return target[prop];
-    },
-    set(target, prop, value) {
-      if (!proxyStateTree.isTrackingMutations) {
-        throw new Error(
-          `proxy-state-tree - You are mutating the path "${path
-            .concat(prop)
-            .join(".")}", but it is not allowed`
-        );
-      }
-      proxyStateTree.mutations.push({
-        method: "set",
-        path: path.concat(prop),
-        args: [value]
-      });
-
-      return Reflect.set(target, prop, value);
-    },
-    deleteProperty(target, prop) {
-      proxyStateTree.mutations.push({
-        method: "unset",
-        path: path.concat(prop),
-        args: []
-      });
-
-      delete target[prop];
-
-      return true;
-    }
-  });
+function createProxyState(tree, value, path) {
+	value[PROXY_STATE] = {
+		tree,
+		path
+	};
+	return value;
 }
 
-const arrayMutations = ["push", "shift", "pop", "unshift", "splice"];
-
-function proxifyArray(proxyStateTree, array, path) {
-  return new Proxy(array, {
-    get(target, prop) {
-      if (prop === IS_PROXY) {
-        return true;
-      }
-
-      const value = target[prop];
-      const nestedPath = path.concat(prop);
-
-      if (proxyStateTree.isTrackingPaths) {
-        proxyStateTree.paths.push(nestedPath);
-      }
-
-      if (arrayMutations.indexOf(prop) >= 0) {
-        if (!proxyStateTree.isTrackingMutations) {
-          throw new Error(
-            `proxy-state-tree - You are mutating the path "${path
-              .concat(prop)
-              .join(".")}", but it is not allowed`
-          );
-        }
-        return (...args) => {
-          proxyStateTree.mutations.push({
-            method: prop,
-            path: path,
-            args: args
-          });
-
-          return target[prop](...args);
-        };
-      }
-
-      target[prop] = proxify(proxyStateTree, value, nestedPath);
-
-      return target[prop];
-    }
-  });
+function createProxy(tree, value, path, handler) {
+	return value[PROXY_STATE]
+		? value
+		: new Proxy(createProxyState(tree, value, path), handler);
 }
 
-function proxify(proxyStateTree, value, path) {
-  if (Array.isArray(value)) {
-    return proxifyArray(proxyStateTree, value, path);
-  } else if (isPlainObject(value)) {
-    return proxifyObject(proxyStateTree, value, path);
-  }
+const arrayMutations = ['push', 'shift', 'pop', 'unshift', 'splice'];
+const objectHandler = {
+	get(target, prop) {
+		if (prop === IS_PROXY) return true;
+		if (prop === PROXY_STATE) return target[PROXY_STATE];
 
-  return value;
+		const { tree, path } = target[PROXY_STATE];
+
+		const value = target[prop];
+		const nestedPath = path.concat(prop);
+
+		if (tree.isTrackingPaths) {
+			tree.paths.push(nestedPath);
+		}
+
+		if (typeof value === 'function') {
+			return value(tree, nestedPath);
+		}
+
+		return (target[prop] = proxify(tree, value, nestedPath));
+	},
+	set(target, prop, value) {
+		const { tree, path } = target[PROXY_STATE];
+
+		if (!tree.isTrackingMutations) {
+			throw new Error(
+				`proxy-state-tree - You are mutating the path "${path
+					.concat(prop)
+					.join('.')}", but it is not allowed`
+			);
+		}
+		tree.mutations.push({
+			method: 'set',
+			path: path.concat(prop),
+			args: [value]
+		});
+
+		return Reflect.set(target, prop, value);
+	},
+	deleteProperty(target, prop) {
+		const { tree, path } = target[PROXY_STATE];
+
+		tree.mutations.push({
+			method: 'unset',
+			path: path.concat(prop),
+			args: []
+		});
+
+		delete target[prop];
+
+		return true;
+	}
+};
+
+const arrayHandler = {
+	get(target, prop) {
+		if (prop === IS_PROXY) return true;
+		if (prop === PROXY_STATE) return target[PROXY_STATE];
+
+		const { tree, path } = target[PROXY_STATE];
+
+		const nestedPath = path.concat(prop);
+
+		if (tree.isTrackingPaths) {
+			tree.paths.push(nestedPath);
+		}
+
+		if (arrayMutations.indexOf(prop) >= 0) {
+			if (!tree.isTrackingMutations) {
+				throw new Error(
+					`proxy-state-tree - You are mutating the path "${path
+						.concat(prop)
+						.join('.')}", but it is not allowed`
+				);
+			}
+			return (...args) => {
+				tree.mutations.push({
+					method: prop,
+					path: path,
+					args: args
+				});
+
+				return target[prop](...args);
+			};
+		}
+
+		return (target[prop] = proxify(tree, target[prop], nestedPath));
+	}
+};
+
+function proxify(tree, value, path) {
+	if (Array.isArray(value)) {
+		return createProxy(tree, value, path, arrayHandler);
+	} else if (isPlainObject(value)) {
+		return createProxy(tree, value, path, objectHandler);
+	}
+	return value;
 }
 
+export { IS_PROXY };
 export default proxify;


### PR DESCRIPTION
Using Symbol will free the implementation from prefixing props using "__" to create pseudo private members and allows the proxy implementation to not shadow any property names. For testing the symbol is exported and can be used as a normal property accessor. 

While working with proxies I noticed that they are quite a bit faster with constant handlers. Refactoring the implementation to store all needed state like `tree` and `path` on each `target` using another Symbol and reference the constant objects `arrayHandler`/`objectHandler` from the `proxify` method. 

The current formatting of the code isn't valid (using eslint/standard) I mostly left these errors to make it easier to compare this PR. 