### PR TITLE
Refactor using string concat and Set()

### DIFF
--- a/benchmarks/basic.js
+++ b/benchmarks/basic.js
@@ -1,0 +1,42 @@
+import ProxyStateTree from "../src/index.js";
+import deepClone from "lodash.clonedeep";
+
+describe("very basic performance test", () => {
+  const MAX = 10000;
+
+  function measure(name, fn) {
+    global.gc && global.gc();
+    test(name, fn);
+  }
+
+  const baseState = [...Array(100).keys()];
+
+  {
+    const state = deepClone(baseState);
+    measure("access property (plain)", () => {
+      let counter = 0;
+      for (let i = 0; i < MAX; i++) {
+        counter += state[i % state.length];
+      }
+      expect(counter).toBe(
+        (((state.length - 1) * state.length) / 2) * (MAX / state.length)
+      );
+    });
+  }
+
+  {
+    const tree = new ProxyStateTree(deepClone(baseState));
+    const state = tree.get();
+    measure("tracking access to property (proxy)", () => {
+      let counter = 0;
+      tree.startPathsTracking();
+      for (let i = 0; i < MAX; i++) {
+        counter += state[i % state.length];
+      }
+      tree.stopPathsTracking();
+      expect(counter).toBe(
+        (((state.length - 1) * state.length) / 2) * (MAX / state.length)
+      );
+    });
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-state-tree",
-  "version": "1.0.0-alpha1",
+  "version": "1.0.0-alpha3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3391,7 +3391,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -3474,8 +3473,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
@@ -4172,6 +4170,12 @@
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
     "lodash.sortby": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,13 @@
 		"type": "git",
 		"url": "git+https://github.com/christianalfoni/proxy-state-tree.git"
 	},
-	"keywords": [ "state", "proxy", "mobx", "vue", "store" ],
+	"keywords": [
+		"state",
+		"proxy",
+		"mobx",
+		"vue",
+		"store"
+	],
 	"author": "Christian Alfoni",
 	"license": "MIT",
 	"bugs": {
@@ -38,5 +44,8 @@
 		"jest": "^23.1.0",
 		"prettier": "^1.13.5",
 		"rollup": "^0.60.7"
+	},
+	"dependencies": {
+		"is-plain-object": "^2.0.4"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"build": "npm run build:cjs && npm run build:es",
 		"build:cjs": "rollup src/index.js --file dist/proxy-state-tree.cjs.js --format cjs",
 		"build:es": "rollup src/index.js --file dist/proxy-state-tree.es.js --format es",
-		"test": "jest"
+		"test": "jest",
+		"test:perf": "node --expose-gc node_modules/jest/bin/jest.js --testRegex 'benchmarks/.*?js$'"
 	},
 	"repository": {
 		"type": "git",
@@ -42,6 +43,7 @@
 		"eslint-plugin-promise": "^3.5.0",
 		"eslint-plugin-standard": "^3.0.1",
 		"jest": "^23.1.0",
+		"lodash.clonedeep": "^4.5.0",
 		"prettier": "^1.13.5",
 		"rollup": "^0.60.7"
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -1,103 +1,107 @@
-import proxify from './proxify';
+import proxify, { IS_PROXY } from "./proxify";
 
 class ProxyStateTree {
-	constructor(state) {
-		this.state = state;
-		this.pathDependencies = {};
-		this.mutations = [];
-		this.paths = [];
-		this.isTrackingPaths = false;
-		this.isTrackingMutations = false;
-		this.proxy = proxify(this, state, []);
-	}
-	get() {
-		return this.proxy;
-	}
-	startMutationTracking() {
-		const currentMutations = this.mutations.slice();
+  constructor(state) {
+    this.state = state;
+    this.pathDependencies = {};
+    this.mutations = [];
+    this.paths = new Set();
+    this.isTrackingPaths = false;
+    this.isTrackingMutations = false;
+    this.proxy = proxify(this, state);
+  }
+  get() {
+    return this.proxy;
+  }
+  startMutationTracking() {
+    const currentMutations = this.mutations.slice();
 
-		this.isTrackingMutations = true;
-		this.mutations.length = 0;
+    this.isTrackingMutations = true;
+    this.mutations.length = 0;
 
-		return currentMutations;
-	}
-	stopMutationTracking() {
-		for (let callback in this.mutationCallbacks) {
-			this.mutationCallbacks[callback](this.mutations);
-		}
-		for (let mutation in this.mutations) {
-			const path = this.mutations[mutation].path.join('.');
-			if (this.pathDependencies[path]) {
-				for (let pathCallback in this.pathDependencies[path]) {
-					this.pathDependencies[path][pathCallback]();
-				}
-			}
-		}
-		this.isTrackingMutations = false;
+    return currentMutations;
+  }
+  stopMutationTracking() {
+    for (let callback in this.mutationCallbacks) {
+      this.mutationCallbacks[callback](this.mutations);
+    }
+    for (let mutation in this.mutations) {
+      const path = this.mutations[mutation].path;
+      if (this.pathDependencies[path]) {
+        for (let pathCallback in this.pathDependencies[path]) {
+          this.pathDependencies[path][pathCallback]();
+        }
+      }
+    }
+    this.isTrackingMutations = false;
 
-		return this.mutations;
-	}
-	startPathsTracking() {
-		const currentPaths = this.paths.slice();
+    return this.mutations;
+  }
+  startPathsTracking() {
+    this.isTrackingPaths = true;
+    const currentPaths = Array.from(this.paths);
+    this.paths.clear();
+    return currentPaths;
+  }
+  stopPathsTracking() {
+    this.isTrackingPaths = false;
+    return Array.from(this.paths);
+  }
+  addMutationListener(initialPaths, cb) {
+    const pathDependencies = this.pathDependencies;
+    let currentStringPaths = initialPaths;
 
-		this.isTrackingPaths = true;
-		this.paths.length = 0;
+    for (let index in currentStringPaths) {
+      const currentStringPath = currentStringPaths[index];
+      pathDependencies[currentStringPath] = pathDependencies[currentStringPath]
+        ? pathDependencies[currentStringPath].concat(cb)
+        : [cb];
+    }
 
-		return currentPaths;
-	}
-	stopPathsTracking() {
-		this.isTrackingPaths = false;
+    return {
+      update(newPaths) {
+        const newStringPaths = newPaths;
 
-		return this.paths;
-	}
-	addMutationListener(initialPaths, cb) {
-		const pathDependencies = this.pathDependencies;
-		let currentStringPaths = initialPaths.map((path) => path.join('.'));
+        for (let index in currentStringPaths) {
+          const currentStringPath = currentStringPaths[index];
 
-		for (let index in currentStringPaths) {
-			const currentStringPath = currentStringPaths[index];
-			pathDependencies[currentStringPath] = pathDependencies[currentStringPath]
-				? pathDependencies[currentStringPath].concat(cb)
-				: [ cb ];
-		}
+          if (newStringPaths.indexOf(currentStringPath) === -1) {
+            pathDependencies[currentStringPath].splice(
+              pathDependencies[currentStringPath].indexOf(cb),
+              1
+            );
+          }
+        }
 
-		return {
-			update(newPaths) {
-				const newStringPaths = newPaths.map((path) => path.join('.'));
+        for (let index in newStringPaths) {
+          const newStringPath = newStringPaths[index];
 
-				for (let index in currentStringPaths) {
-					const currentStringPath = currentStringPaths[index];
+          if (currentStringPaths.indexOf(newStringPath) === -1) {
+            pathDependencies[newStringPath] = pathDependencies[newStringPath]
+              ? pathDependencies[newStringPath].concat(cb)
+              : [cb];
+          }
+        }
 
-					if (newStringPaths.indexOf(currentStringPath) === -1) {
-						pathDependencies[currentStringPath].splice(pathDependencies[currentStringPath].indexOf(cb), 1);
-					}
-				}
+        currentStringPaths = newStringPaths;
+      },
+      dispose() {
+        for (let index in currentStringPaths) {
+          const currentStringPath = currentStringPaths[index];
 
-				for (let index in newStringPaths) {
-					const newStringPath = newStringPaths[index];
+          pathDependencies[currentStringPath].splice(
+            pathDependencies[currentStringPath].indexOf(cb),
+            1
+          );
 
-					if (currentStringPaths.indexOf(newStringPath) === -1) {
-						pathDependencies[newStringPath] = pathDependencies[newStringPath]
-							? pathDependencies[newStringPath].concat(cb)
-							: [ cb ];
-					}
-				}
-
-				currentStringPaths = newStringPaths;
-			},
-			dispose() {
-				for (let index in currentStringPaths) {
-					const currentStringPath = currentStringPaths[index];
-
-					pathDependencies[currentStringPath].splice(pathDependencies[currentStringPath].indexOf(cb), 1);
-
-					if (!pathDependencies[currentStringPath].length) {
-						delete pathDependencies[currentStringPath];
-					}
-				}
-			}
-		};
-	}
+          if (!pathDependencies[currentStringPath].length) {
+            delete pathDependencies[currentStringPath];
+          }
+        }
+      }
+    };
+  }
 }
 
+export { IS_PROXY };
 export default ProxyStateTree;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,325 +1,325 @@
-import ProxyStateTree from './';
+import ProxyStateTree, { IS_PROXY } from "./";
 
-describe('CREATION', () => {
-	test('should create a ProxyStateTree instance', () => {
-		const tree = new ProxyStateTree({});
+describe("CREATION", () => {
+  test("should create a ProxyStateTree instance", () => {
+    const tree = new ProxyStateTree({});
 
-		expect(tree).toBeInstanceOf(ProxyStateTree);
-	});
+    expect(tree).toBeInstanceOf(ProxyStateTree);
+  });
 
-	test('should create proxy of root state', () => {
-		const state = {};
-		const tree = new ProxyStateTree(state);
+  test("should create proxy of root state", () => {
+    const state = {};
+    const tree = new ProxyStateTree(state);
 
-		expect(tree.get().__is_proxy).toBeTruthy();
-	});
+    expect(tree.get()[IS_PROXY]).toBeTruthy();
+  });
 
-	test('should not create nested proxies when initialized', () => {
-		const state = {
-			foo: {}
-		};
-		new ProxyStateTree(state); // eslint-disable-line
+  test("should not create nested proxies when initialized", () => {
+    const state = {
+      foo: {}
+    };
+    new ProxyStateTree(state); // eslint-disable-line
 
-		expect(state.foo.__is_proxy).not.toBeTruthy();
-	});
+    expect(state.foo[IS_PROXY]).not.toBeTruthy();
+  });
 });
 
-describe('OBJECTS', () => {
-	describe('ACCESS', () => {
-		test('should create proxy when accessed', () => {
-			const state = {
-				foo: {}
-			};
-			const tree = new ProxyStateTree(state);
-			tree.get().foo; // eslint-disable-line
-			expect(state.foo.__is_proxy).toBeTruthy();
-		});
-		test('should access properties', () => {
-			const state = {
-				foo: {
-					bar: 'baz'
-				}
-			};
-			const tree = new ProxyStateTree(state);
-			expect(tree.get().foo.bar).toBe('baz');
-		});
-		test('should track access properties', () => {
-			const state = {
-				foo: {
-					bar: 'baz'
-				}
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startPathsTracking();
-			expect(tree.get().foo.bar).toBe('baz');
-			const paths = tree.stopPathsTracking();
-			expect(paths).toEqual([ [ 'foo' ], [ 'foo', 'bar' ] ]);
-		});
-	});
-	describe('MUTATIONS', () => {
-		test('should throw when mutating without tracking', () => {
-			const state = {
-				foo: 'bar'
-			};
-			const tree = new ProxyStateTree(state);
-			expect(() => {
-				tree.get().foo = 'bar2';
-			}).toThrow();
-		});
-		test('should track SET mutations', () => {
-			const state = {
-				foo: 'bar'
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startMutationTracking();
-			tree.get().foo = 'bar2';
-			const mutations = tree.stopMutationTracking();
-			expect(mutations).toEqual([
-				{
-					method: 'set',
-					path: [ 'foo' ],
-					args: [ 'bar2' ]
-				}
-			]);
-			expect(tree.get().foo).toBe('bar2');
-		});
-		test('should track UNSET mutations', () => {
-			const state = {
-				foo: 'bar'
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startMutationTracking();
-			delete tree.get().foo;
-			const mutations = tree.stopMutationTracking();
-			expect(mutations).toEqual([
-				{
-					method: 'unset',
-					path: [ 'foo' ],
-					args: []
-				}
-			]);
-			expect(tree.get().foo).toBe(undefined);
-		});
-	});
+describe("OBJECTS", () => {
+  describe("ACCESS", () => {
+    test("should create proxy when accessed", () => {
+      const state = {
+        foo: {}
+      };
+      const tree = new ProxyStateTree(state);
+      tree.get().foo; // eslint-disable-line
+      expect(state.foo[IS_PROXY]).toBeTruthy();
+    });
+    test("should access properties", () => {
+      const state = {
+        foo: {
+          bar: "baz"
+        }
+      };
+      const tree = new ProxyStateTree(state);
+      expect(tree.get().foo.bar).toBe("baz");
+    });
+    test("should track access properties", () => {
+      const state = {
+        foo: {
+          bar: "baz"
+        }
+      };
+      const tree = new ProxyStateTree(state);
+      tree.startPathsTracking();
+      expect(tree.get().foo.bar).toBe("baz");
+      const paths = tree.stopPathsTracking();
+      expect(paths).toEqual(["foo", "foo.bar"]);
+    });
+  });
+  describe("MUTATIONS", () => {
+    test("should throw when mutating without tracking", () => {
+      const state = {
+        foo: "bar"
+      };
+      const tree = new ProxyStateTree(state);
+      expect(() => {
+        tree.get().foo = "bar2";
+      }).toThrow();
+    });
+    test("should track SET mutations", () => {
+      const state = {
+        foo: "bar"
+      };
+      const tree = new ProxyStateTree(state);
+      tree.startMutationTracking();
+      tree.get().foo = "bar2";
+      const mutations = tree.stopMutationTracking();
+      expect(mutations).toEqual([
+        {
+          method: "set",
+          path: "foo",
+          args: ["bar2"]
+        }
+      ]);
+      expect(tree.get().foo).toBe("bar2");
+    });
+    test("should track UNSET mutations", () => {
+      const state = {
+        foo: "bar"
+      };
+      const tree = new ProxyStateTree(state);
+      tree.startMutationTracking();
+      delete tree.get().foo;
+      const mutations = tree.stopMutationTracking();
+      expect(mutations).toEqual([
+        {
+          method: "unset",
+          path: "foo",
+          args: []
+        }
+      ]);
+      expect(tree.get().foo).toBe(undefined);
+    });
+  });
 });
 
-describe('ARRAYS', () => {
-	describe('ACCESS', () => {
-		test('should create proxies of arrays', () => {
-			const state = {
-				foo: []
-			};
-			const tree = new ProxyStateTree(state);
-			tree.get().foo; // eslint-disable-line
-			expect(state.foo.__is_proxy).toBeTruthy();
-		});
-		test('should access properties', () => {
-			const state = {
-				foo: [ 'bar' ]
-			};
-			const tree = new ProxyStateTree(state);
-			expect(tree.get().foo[0]).toBe('bar');
-		});
-		test('should track access properties', () => {
-			const state = {
-				foo: [ 'bar' ]
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startPathsTracking();
-			expect(tree.get().foo[0]).toBe('bar');
-			const paths = tree.stopPathsTracking();
-			expect(paths).toEqual([ [ 'foo' ], [ 'foo', '0' ] ]);
-		});
-	});
-	describe('MUTATIONS', () => {
-		test('should throw when mutating without tracking', () => {
-			const state = {
-				foo: []
-			};
-			const tree = new ProxyStateTree(state);
-			expect(() => {
-				tree.get().foo.push('foo');
-			}).toThrow();
-		});
-		test('should track PUSH mutations', () => {
-			const state = {
-				foo: []
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startMutationTracking();
-			tree.get().foo.push('bar');
-			const mutations = tree.stopMutationTracking();
-			expect(mutations).toEqual([
-				{
-					method: 'push',
-					path: [ 'foo' ],
-					args: [ 'bar' ]
-				}
-			]);
+describe("ARRAYS", () => {
+  describe("ACCESS", () => {
+    test("should create proxies of arrays", () => {
+      const state = {
+        foo: []
+      };
+      const tree = new ProxyStateTree(state);
+      tree.get().foo; // eslint-disable-line
+      expect(state.foo[IS_PROXY]).toBeTruthy();
+    });
+    test("should access properties", () => {
+      const state = {
+        foo: "bar"
+      };
+      const tree = new ProxyStateTree(state);
+      expect(tree.get().foo[0]).toBe("b");
+    });
+    test("should track access properties", () => {
+      const state = {
+        foo: ["bar"]
+      };
+      const tree = new ProxyStateTree(state);
+      tree.startPathsTracking();
+      expect(tree.get().foo[0]).toBe("bar");
+      const paths = tree.stopPathsTracking();
+      expect(paths).toEqual(["foo", "foo.0"]);
+    });
+  });
+  describe("MUTATIONS", () => {
+    test("should throw when mutating without tracking", () => {
+      const state = {
+        foo: []
+      };
+      const tree = new ProxyStateTree(state);
+      expect(() => {
+        tree.get().foo.push("foo");
+      }).toThrow();
+    });
+    test("should track PUSH mutations", () => {
+      const state = {
+        foo: []
+      };
+      const tree = new ProxyStateTree(state);
+      tree.startMutationTracking();
+      tree.get().foo.push("bar");
+      const mutations = tree.stopMutationTracking();
+      expect(mutations).toEqual([
+        {
+          method: "push",
+          path: "foo",
+          args: ["bar"]
+        }
+      ]);
 
-			// expect(tree.get().foo).toEqual(["bar"]); BUG IN JEST
-			expect(tree.get().foo[0]).toBe('bar');
-		});
-		test('should track POP mutations', () => {
-			const state = {
-				foo: [ 'foo' ]
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startMutationTracking();
-			tree.get().foo.pop();
-			const mutations = tree.stopMutationTracking();
-			expect(mutations).toEqual([
-				{
-					method: 'pop',
-					path: [ 'foo' ],
-					args: []
-				}
-			]);
+      // expect(tree.get().foo).toEqual(["bar"]); BUG IN JEST
+      expect(tree.get().foo[0]).toBe("bar");
+    });
+    test("should track POP mutations", () => {
+      const state = {
+        foo: ["foo"]
+      };
+      const tree = new ProxyStateTree(state);
+      tree.startMutationTracking();
+      tree.get().foo.pop();
+      const mutations = tree.stopMutationTracking();
+      expect(mutations).toEqual([
+        {
+          method: "pop",
+          path: "foo",
+          args: []
+        }
+      ]);
 
-			expect(tree.get().foo.length).toBe(0);
-		});
-		test('should track POP mutations', () => {
-			const state = {
-				foo: [ 'foo' ]
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startMutationTracking();
-			tree.get().foo.shift();
-			const mutations = tree.stopMutationTracking();
-			expect(mutations).toEqual([
-				{
-					method: 'shift',
-					path: [ 'foo' ],
-					args: []
-				}
-			]);
+      expect(tree.get().foo.length).toBe(0);
+    });
+    test("should track POP mutations", () => {
+      const state = {
+        foo: ["foo"]
+      };
+      const tree = new ProxyStateTree(state);
+      tree.startMutationTracking();
+      tree.get().foo.shift();
+      const mutations = tree.stopMutationTracking();
+      expect(mutations).toEqual([
+        {
+          method: "shift",
+          path: "foo",
+          args: []
+        }
+      ]);
 
-			expect(tree.get().foo.length).toBe(0);
-		});
-		test('should track UNSHIFT mutations', () => {
-			const state = {
-				foo: []
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startMutationTracking();
-			tree.get().foo.unshift('foo');
-			const mutations = tree.stopMutationTracking();
-			expect(mutations).toEqual([
-				{
-					method: 'unshift',
-					path: [ 'foo' ],
-					args: [ 'foo' ]
-				}
-			]);
+      expect(tree.get().foo.length).toBe(0);
+    });
+    test("should track UNSHIFT mutations", () => {
+      const state = {
+        foo: []
+      };
+      const tree = new ProxyStateTree(state);
+      tree.startMutationTracking();
+      tree.get().foo.unshift("foo");
+      const mutations = tree.stopMutationTracking();
+      expect(mutations).toEqual([
+        {
+          method: "unshift",
+          path: "foo",
+          args: ["foo"]
+        }
+      ]);
 
-			expect(tree.get().foo[0]).toBe('foo');
-		});
-		test('should track SPLICE mutations', () => {
-			const state = {
-				foo: [ 'foo' ]
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startMutationTracking();
-			tree.get().foo.splice(0, 1, 'bar');
-			const mutations = tree.stopMutationTracking();
-			expect(mutations).toEqual([
-				{
-					method: 'splice',
-					path: [ 'foo' ],
-					args: [ 0, 1, 'bar' ]
-				}
-			]);
+      expect(tree.get().foo[0]).toBe("foo");
+    });
+    test("should track SPLICE mutations", () => {
+      const state = {
+        foo: ["foo"]
+      };
+      const tree = new ProxyStateTree(state);
+      tree.startMutationTracking();
+      tree.get().foo.splice(0, 1, "bar");
+      const mutations = tree.stopMutationTracking();
+      expect(mutations).toEqual([
+        {
+          method: "splice",
+          path: "foo",
+          args: [0, 1, "bar"]
+        }
+      ]);
 
-			expect(tree.get().foo[0]).toBe('bar');
-		});
-	});
+      expect(tree.get().foo[0]).toBe("bar");
+    });
+  });
 });
 
-describe('FUNCTIONS', () => {
-	test('should call functions in the tree when accessed', () => {
-		const state = {
-			foo: () => 'bar'
-		};
-		const tree = new ProxyStateTree(state);
+describe("FUNCTIONS", () => {
+  test("should call functions in the tree when accessed", () => {
+    const state = {
+      foo: () => "bar"
+    };
+    const tree = new ProxyStateTree(state);
 
-		expect(tree.get().foo).toBe('bar');
-	});
-	test('should pass proxy-state-tree instance and path', () => {
-		const state = {
-			foo: (proxyStateTree, path) => {
-				expect(proxyStateTree).toBe(tree);
-				expect(path).toEqual([ 'foo' ]);
+    expect(tree.get().foo).toBe("bar");
+  });
+  test("should pass proxy-state-tree instance and path", () => {
+    const state = {
+      foo: (proxyStateTree, path) => {
+        expect(proxyStateTree).toBe(tree);
+        expect(path).toEqual("foo");
 
-				return 'bar';
-			}
-		};
-		const tree = new ProxyStateTree(state);
+        return "bar";
+      }
+    };
+    const tree = new ProxyStateTree(state);
 
-		expect(tree.get().foo).toBe('bar');
-	});
+    expect(tree.get().foo).toBe("bar");
+  });
 });
 
-describe('REACTIONS', () => {
-	test('should be able to register a listener using paths', () => {
-		let reactionCount = 0;
-		const tree = new ProxyStateTree({
-			foo: 'bar'
-		});
-		const state = tree.get();
-		tree.startPathsTracking();
-		state.foo;
-		const paths = tree.stopPathsTracking();
-		tree.addMutationListener(paths, () => {
-			reactionCount++;
-		});
-		tree.startMutationTracking();
-		state.foo = 'bar2';
-		tree.stopMutationTracking();
-		expect(reactionCount).toBe(1);
-	});
-	test('should be able to update listener using paths', () => {
-		const tree = new ProxyStateTree({
-			foo: 'bar',
-			bar: 'baz'
-		});
-		const state = tree.get();
-		function render() {
-			tree.startPathsTracking();
-			if (state.foo === 'bar') {
-			} else {
-				state.bar;
-			}
-			return tree.stopPathsTracking();
-		}
-		const listener = tree.addMutationListener(render(), () => {
-			listener.update(render());
-		});
-		tree.startMutationTracking();
-		state.foo = 'bar2';
-		tree.stopMutationTracking();
-		expect(tree.pathDependencies.foo.length).toBe(1);
-		expect(tree.pathDependencies.bar.length).toBe(1);
-	});
-	test('should be able to remove listener', () => {
-		const tree = new ProxyStateTree({
-			foo: 'bar',
-			bar: 'baz'
-		});
-		const state = tree.get();
-		function render() {
-			tree.startPathsTracking();
-			if (state.foo === 'bar') {
-			} else {
-				state.bar;
-			}
-			return tree.stopPathsTracking();
-		}
-		const listener = tree.addMutationListener(render(), () => {
-			listener.dispose();
-		});
-		tree.startMutationTracking();
-		state.foo = 'bar2';
-		tree.stopMutationTracking();
-		expect(tree.pathDependencies).toEqual({});
-	});
+describe("REACTIONS", () => {
+  test("should be able to register a listener using paths", () => {
+    let reactionCount = 0;
+    const tree = new ProxyStateTree({
+      foo: "bar"
+    });
+    const state = tree.get();
+    tree.startPathsTracking();
+    state.foo;
+    const paths = tree.stopPathsTracking();
+    tree.addMutationListener(paths, () => {
+      reactionCount++;
+    });
+    tree.startMutationTracking();
+    state.foo = "bar2";
+    tree.stopMutationTracking();
+    expect(reactionCount).toBe(1);
+  });
+  test("should be able to update listener using paths", () => {
+    const tree = new ProxyStateTree({
+      foo: "bar",
+      bar: "baz"
+    });
+    const state = tree.get();
+    function render() {
+      tree.startPathsTracking();
+      if (state.foo === "bar") {
+      } else {
+        state.bar;
+      }
+      return tree.stopPathsTracking();
+    }
+    const listener = tree.addMutationListener(render(), () => {
+      listener.update(render());
+    });
+    tree.startMutationTracking();
+    state.foo = "bar2";
+    tree.stopMutationTracking();
+    expect(tree.pathDependencies.foo.length).toBe(1);
+    expect(tree.pathDependencies.bar.length).toBe(1);
+  });
+  test("should be able to remove listener", () => {
+    const tree = new ProxyStateTree({
+      foo: "bar",
+      bar: "baz"
+    });
+    const state = tree.get();
+    function render() {
+      tree.startPathsTracking();
+      if (state.foo === "bar") {
+      } else {
+        state.bar;
+      }
+      return tree.stopPathsTracking();
+    }
+    const listener = tree.addMutationListener(render(), () => {
+      listener.dispose();
+    });
+    tree.startMutationTracking();
+    state.foo = "bar2";
+    tree.stopMutationTracking();
+    expect(tree.pathDependencies).toEqual({});
+  });
 });

--- a/src/proxify.js
+++ b/src/proxify.js
@@ -92,12 +92,14 @@ function createObjectProxy(tree, value, path) {
 }
 
 function proxify(tree, value, path) {
-  if (value[IS_PROXY]) {
-    return value;
-  } else if (Array.isArray(value)) {
-    return createArrayProxy(tree, value, path);
-  } else if (isPlainObject(value)) {
-    return createObjectProxy(tree, value, path);
+  if (value) {
+    if (value[IS_PROXY]) {
+      return value;
+    } else if (Array.isArray(value)) {
+      return createArrayProxy(tree, value, path);
+    } else if (isPlainObject(value)) {
+      return createObjectProxy(tree, value, path);
+    }
   }
   return value;
 }


### PR DESCRIPTION
As discussed on discord:

  * Rewrote path tracking to use string concatination instead of arrays 
       - This changed the shape of the mutation object. `path` is now a `string` instead of an array. 
  * Use a ES6 `Set()` to keep track of accessed paths to avoid tracking the same path multiple times.
  * Added a *very* basic benchmark. This is synthetic and should be used with extreme caution. This is only used to detect issues in the implementation that can be worked around.  

The code in this PR is formatted according to the eslint rules. 