### PR TITLE
Inital draft for mutation tracking rewrite

### DIFF
--- a/benchmarks/basic.js
+++ b/benchmarks/basic.js
@@ -26,14 +26,16 @@ describe("very basic performance test", () => {
 
   {
     const tree = new ProxyStateTree(deepClone(baseState));
-    const state = tree.get();
+    const tracker = tree.newTracker();
+    const state = tracker.get();
     measure("tracking access to property (proxy)", () => {
+      tracker.startPathsTracking();
       let counter = 0;
-      tree.startPathsTracking();
       for (let i = 0; i < MAX; i++) {
         counter += state[i % state.length];
       }
-      tree.stopPathsTracking();
+      tracker.stopPathsTracking();
+
       expect(counter).toBe(
         (((state.length - 1) * state.length) / 2) * (MAX / state.length)
       );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-state-tree",
-  "version": "1.0.0-alpha3",
+  "version": "1.0.0-alpha4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,13 @@
 		"type": "git",
 		"url": "git+https://github.com/christianalfoni/proxy-state-tree.git"
 	},
-	"keywords": [ "state", "proxy", "mobx", "vue", "store" ],
+	"keywords": [
+		"state",
+		"proxy",
+		"mobx",
+		"vue",
+		"store"
+	],
 	"author": "Christian Alfoni",
 	"license": "MIT",
 	"bugs": {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,389 +1,454 @@
-import ProxyStateTree, { IS_PROXY } from './';
+import ProxyStateTree, { IS_PROXY } from "./";
 
-describe('CREATION', () => {
-	test('should create a ProxyStateTree instance', () => {
-		const tree = new ProxyStateTree({});
+describe("CREATION", () => {
+  test("should create a ProxyStateTree instance", () => {
+    const tree = new ProxyStateTree({});
 
-		expect(tree).toBeInstanceOf(ProxyStateTree);
-	});
+    expect(tree).toBeInstanceOf(ProxyStateTree);
+  });
 
-	test('should create proxy of root state', () => {
-		const state = {};
-		const tree = new ProxyStateTree(state);
+  test("should create proxy of root state", () => {
+    const state = {};
+    const tree = new ProxyStateTree(state);
 
-		expect(tree.get()[IS_PROXY]).toBeTruthy();
-	});
+    expect(tree.newTracker().get()[IS_PROXY]).toBeTruthy();
+  });
 
-	test('should not create nested proxies when initialized', () => {
-		const state = {
-			foo: {}
-		};
-		new ProxyStateTree(state); // eslint-disable-line
+  test("should not create proxies when initialized", () => {
+    const state = {
+      foo: {}
+    };
+    new ProxyStateTree(state); // eslint-disable-line
 
-		expect(state.foo[IS_PROXY]).not.toBeTruthy();
-	});
+    expect(state.foo[IS_PROXY]).not.toBeTruthy();
+  });
 });
 
-describe('OBJECTS', () => {
-	describe('ACCESS', () => {
-		test('should create proxy when accessed', () => {
-			const state = {
-				foo: {}
-			};
-			const tree = new ProxyStateTree(state);
-			tree.get().foo; // eslint-disable-line
-			expect(state.foo[IS_PROXY]).toBeTruthy();
-		});
-		test('should access properties', () => {
-			const state = {
-				foo: {
-					bar: 'baz'
-				}
-			};
-			const tree = new ProxyStateTree(state);
-			expect(tree.get().foo.bar).toBe('baz');
-		});
-		test('should track access properties', () => {
-			const state = {
-				foo: {
-					bar: 'baz'
-				}
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startPathsTracking();
-			expect(tree.get().foo.bar).toBe('baz');
-			const paths = tree.stopPathsTracking();
-			expect(paths).toEqual([ 'foo', 'foo.bar' ]);
-		});
-	});
-	describe('MUTATIONS', () => {
-		test('should throw when mutating without tracking', () => {
-			const state = {
-				foo: 'bar'
-			};
-			const tree = new ProxyStateTree(state);
-			expect(() => {
-				tree.get().foo = 'bar2';
-			}).toThrow();
-		});
-		test('should track SET mutations', () => {
-			const state = {
-				foo: 'bar'
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startMutationTracking();
-			tree.get().foo = 'bar2';
-			const mutations = tree.stopMutationTracking();
-			expect(mutations).toEqual([
-				{
-					method: 'set',
-					path: 'foo',
-					args: [ 'bar2' ]
-				}
-			]);
-			expect(tree.get().foo).toBe('bar2');
-		});
-		test('should track UNSET mutations', () => {
-			const state = {
-				foo: 'bar'
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startMutationTracking();
-			delete tree.get().foo;
-			const mutations = tree.stopMutationTracking();
-			expect(mutations).toEqual([
-				{
-					method: 'unset',
-					path: 'foo',
-					args: []
-				}
-			]);
-			expect(tree.get().foo).toBe(undefined);
-		});
-	});
+describe("OBJECTS", () => {
+  describe("ACCESS", () => {
+    test("should not create proxy when accessed via tracker", () => {
+      const state = {
+        foo: {}
+      };
+      const tree = new ProxyStateTree(state);
+      const tracker = tree.newTracker();
+      tracker.get().foo; // eslint-disable-line
+      expect(state.foo[IS_PROXY]).toBeUndefined();
+      expect(tracker.get().foo[IS_PROXY]).toBeTruthy();
+    });
+    test("should access properties", () => {
+      const state = {
+        foo: {
+          bar: "baz"
+        }
+      };
+      const tree = new ProxyStateTree(state);
+      expect(tree.newTracker().get().foo.bar).toBe("baz");
+    });
+    test("should track access properties", () => {
+      const state = {
+        foo: {
+          bar: "baz"
+        }
+      };
+      const tree = new ProxyStateTree(state);
+      const tracker = tree.newTracker();
+      tracker.startPathsTracking();
+      expect(tracker.get().foo.bar).toBe("baz");
+      const paths = tracker.stopPathsTracking();
+      expect(paths).toEqual(["foo", "foo.bar"]);
+    });
+  });
+  describe("MUTATIONS", () => {
+    test("should throw when mutating without tracking", () => {
+      const state = {
+        foo: "bar"
+      };
+      const tree = new ProxyStateTree(state);
+      const tracker = tree.newTracker();
+      expect(() => {
+        tracker.get().foo = "bar2";
+      }).toThrow();
+    });
+    test("should track any SET mutations in dev mode", () => {
+      const state = {
+        foo: "bar"
+      };
+      const tree = new ProxyStateTree(state, true);
+      const tracker = tree.newTracker();
+      tracker.startMutationTracking();
+      tracker.get().foo = "bar2";
+      const mutations = tracker.stopMutationTracking();
+      expect(mutations).toEqual([
+        {
+          method: "set",
+          path: "foo",
+          args: ["bar2"]
+        }
+      ]);
+      expect(tracker.get().foo).toBe("bar2");
+    });
+    test("should track any UNSET mutations in dev mode", () => {
+      const state = {
+        foo: "bar"
+      };
+      const tree = new ProxyStateTree(state, true);
+      const tracker = tree.newTracker();
+      tracker.startMutationTracking();
+      delete tracker.get().foo;
+      const mutations = tracker.stopMutationTracking();
+      expect(mutations).toEqual([
+        {
+          method: "unset",
+          path: "foo",
+          args: []
+        }
+      ]);
+      expect(tracker.get().foo).toBe(undefined);
+    });
+  });
 });
 
-describe('ARRAYS', () => {
-	describe('ACCESS', () => {
-		test('should create proxies of arrays', () => {
-			const state = {
-				foo: []
-			};
-			const tree = new ProxyStateTree(state);
-			tree.get().foo; // eslint-disable-line
-			expect(state.foo[IS_PROXY]).toBeTruthy();
-		});
-		test('should access properties', () => {
-			const state = {
-				foo: 'bar'
-			};
-			const tree = new ProxyStateTree(state);
-			expect(tree.get().foo[0]).toBe('b');
-		});
-		test('should track access properties', () => {
-			const state = {
-				foo: [ 'bar' ]
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startPathsTracking();
-			expect(tree.get().foo[0]).toBe('bar');
-			const paths = tree.stopPathsTracking();
-			expect(paths).toEqual([ 'foo', 'foo.0' ]);
-		});
-	});
-	describe('MUTATIONS', () => {
-		test('should throw when mutating without tracking', () => {
-			const state = {
-				foo: []
-			};
-			const tree = new ProxyStateTree(state);
-			expect(() => {
-				tree.get().foo.push('foo');
-			}).toThrow();
-		});
-		test('should track PUSH mutations', () => {
-			const state = {
-				foo: []
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startMutationTracking();
-			tree.get().foo.push('bar');
-			const mutations = tree.stopMutationTracking();
-			expect(mutations).toEqual([
-				{
-					method: 'push',
-					path: 'foo',
-					args: [ 'bar' ]
-				}
-			]);
+describe("ARRAYS", () => {
+  describe("ACCESS", () => {
+    test("should create proxies of arrays", () => {
+      const state = {
+        foo: []
+      };
+      const tree = new ProxyStateTree(state);
+      const tracker = tree.newTracker();
+      tracker.get().foo; // eslint-disable-line
+      expect(tracker.get().foo).toBeTruthy();
+    });
+    test("should access properties", () => {
+      const state = {
+        foo: "bar"
+      };
+      const tree = new ProxyStateTree(state);
+      const tracker = tree.newTracker();
+      expect(tracker.get().foo[0]).toBe("b");
+    });
+    test("should track access properties", () => {
+      const state = {
+        foo: ["bar"]
+      };
+      const tree = new ProxyStateTree(state);
+      const tracker = tree.newTracker();
+      tracker.startPathsTracking();
+      expect(tracker.get().foo[0]).toBe("bar");
+      const paths = tracker.stopPathsTracking();
+      expect(paths).toEqual(["foo", "foo.0"]);
+    });
+  });
+  describe("MUTATIONS", () => {
+    test("should throw when mutating without tracking", () => {
+      const state = {
+        foo: []
+      };
+      const tree = new ProxyStateTree(state);
+      const tracker = tree.newTracker();
+      expect(() => {
+        tracker.get().foo.push("foo");
+      }).toThrow();
+    });
+    test("should track any PUSH mutations in dev mode", () => {
+      const state = {
+        foo: []
+      };
+      const tree = new ProxyStateTree(state, true);
+      const tracker = tree.newTracker();
+      tracker.startMutationTracking();
+      tracker.get().foo.push("bar");
+      const mutations = tracker.stopMutationTracking();
+      expect(mutations).toEqual([
+        {
+          method: "push",
+          path: "foo",
+          args: ["bar"]
+        }
+      ]);
 
-			// expect(tree.get().foo).toEqual(["bar"]); BUG IN JEST
-			expect(tree.get().foo[0]).toBe('bar');
-		});
-		test('should track POP mutations', () => {
-			const state = {
-				foo: [ 'foo' ]
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startMutationTracking();
-			tree.get().foo.pop();
-			const mutations = tree.stopMutationTracking();
-			expect(mutations).toEqual([
-				{
-					method: 'pop',
-					path: 'foo',
-					args: []
-				}
-			]);
+      // expect(tree.get().foo).toEqual(["bar"]); BUG IN JEST
+      expect(tracker.get().foo[0]).toBe("bar");
+    });
+    test("should track any POP mutations in dev mode", () => {
+      const state = {
+        foo: ["foo"]
+      };
+      const tree = new ProxyStateTree(state, true);
+      const tracker = tree.newTracker();
+      tracker.startMutationTracking();
+      tracker.get().foo.pop();
+      const mutations = tracker.stopMutationTracking();
+      expect(mutations).toEqual([
+        {
+          method: "pop",
+          path: "foo",
+          args: []
+        }
+      ]);
 
-			expect(tree.get().foo.length).toBe(0);
-		});
-		test('should track POP mutations', () => {
-			const state = {
-				foo: [ 'foo' ]
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startMutationTracking();
-			tree.get().foo.shift();
-			const mutations = tree.stopMutationTracking();
-			expect(mutations).toEqual([
-				{
-					method: 'shift',
-					path: 'foo',
-					args: []
-				}
-			]);
+      expect(tracker.get().foo.length).toBe(0);
+    });
+    test("should track any POP mutations in dev mode", () => {
+      const state = {
+        foo: ["foo"]
+      };
+      const tree = new ProxyStateTree(state, true);
+      const tracker = tree.newTracker();
+      tracker.startMutationTracking();
+      tracker.get().foo.shift();
+      const mutations = tracker.stopMutationTracking();
+      expect(mutations).toEqual([
+        {
+          method: "shift",
+          path: "foo",
+          args: []
+        }
+      ]);
 
-			expect(tree.get().foo.length).toBe(0);
-		});
-		test('should track UNSHIFT mutations', () => {
-			const state = {
-				foo: []
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startMutationTracking();
-			tree.get().foo.unshift('foo');
-			const mutations = tree.stopMutationTracking();
-			expect(mutations).toEqual([
-				{
-					method: 'unshift',
-					path: 'foo',
-					args: [ 'foo' ]
-				}
-			]);
+      expect(tracker.get().foo.length).toBe(0);
+    });
+    test("should track any UNSHIFT mutations in dev mode", () => {
+      const state = {
+        foo: []
+      };
+      const tree = new ProxyStateTree(state, true);
+      const tracker = tree.newTracker();
+      tracker.startMutationTracking();
+      tracker.get().foo.unshift("foo");
+      const mutations = tracker.stopMutationTracking();
+      expect(mutations).toEqual([
+        {
+          method: "unshift",
+          path: "foo",
+          args: ["foo"]
+        }
+      ]);
 
-			expect(tree.get().foo[0]).toBe('foo');
-		});
-		test('should track SPLICE mutations', () => {
-			const state = {
-				foo: [ 'foo' ]
-			};
-			const tree = new ProxyStateTree(state);
-			tree.startMutationTracking();
-			tree.get().foo.splice(0, 1, 'bar');
-			const mutations = tree.stopMutationTracking();
-			expect(mutations).toEqual([
-				{
-					method: 'splice',
-					path: 'foo',
-					args: [ 0, 1, 'bar' ]
-				}
-			]);
+      expect(tracker.get().foo[0]).toBe("foo");
+    });
+    test("should track any SPLICE mutations in", () => {
+      const state = {
+        foo: ["foo"]
+      };
+      const tree = new ProxyStateTree(state, true);
+      const tracker = tree.newTracker();
+      tracker.startMutationTracking();
+      tracker.get().foo.splice(0, 1, "bar");
+      const mutations = tracker.stopMutationTracking();
+      expect(mutations).toEqual([
+        {
+          method: "splice",
+          path: "foo",
+          args: [0, 1, "bar"]
+        }
+      ]);
 
-			expect(tree.get().foo[0]).toBe('bar');
-		});
-	});
+      expect(tracker.get().foo[0]).toBe("bar");
+    });
+  });
 });
 
-describe('FUNCTIONS', () => {
-	test('should call functions in the tree when accessed', () => {
-		const state = {
-			foo: () => 'bar'
-		};
-		const tree = new ProxyStateTree(state);
+describe("FUNCTIONS", () => {
+  test("should call functions in the tree when accessed", () => {
+    const state = {
+      foo: () => "bar"
+    };
+    const tree = new ProxyStateTree(state);
+    const tracker = tree.newTracker();
 
-		expect(tree.get().foo).toBe('bar');
-	});
-	test('should pass proxy-state-tree instance and path', () => {
-		const state = {
-			foo: (proxyStateTree, path) => {
-				expect(proxyStateTree).toBe(tree);
-				expect(path).toEqual('foo');
+    expect(tracker.get().foo).toBe("bar");
+  });
+  test("should pass proxy-state-tree instance and path", () => {
+    const state = {
+      foo: (tracker, path) => {
+        expect(tracker).toBe(tracker);
+        expect(path).toEqual("foo");
 
-				return 'bar';
-			}
-		};
-		const tree = new ProxyStateTree(state);
+        return "bar";
+      }
+    };
+    const tree = new ProxyStateTree(state);
+    const tracker = tree.newTracker();
 
-		expect(tree.get().foo).toBe('bar');
-	});
+    expect(tracker.get().foo).toBe("bar");
+  });
 });
 
-describe('REACTIONS', () => {
-	test('should be able to register a listener using paths', () => {
-		let reactionCount = 0;
-		const tree = new ProxyStateTree({
-			foo: 'bar'
-		});
-		const state = tree.get();
-		tree.startPathsTracking();
-		state.foo;
-		const paths = tree.stopPathsTracking();
-		tree.addMutationListener(paths, () => {
-			reactionCount++;
-		});
-		tree.startMutationTracking();
-		state.foo = 'bar2';
-		tree.stopMutationTracking();
-		expect(reactionCount).toBe(1);
-	});
-	test('should be able to update listener using paths', () => {
-		const tree = new ProxyStateTree({
-			foo: 'bar',
-			bar: 'baz'
-		});
-		const state = tree.get();
-		function render() {
-			tree.startPathsTracking();
-			if (state.foo === 'bar') {
-			} else {
-				state.bar;
-			}
-			return tree.stopPathsTracking();
-		}
-		const listener = tree.addMutationListener(render(), () => {
-			listener.update(render());
-		});
-		tree.startMutationTracking();
-		state.foo = 'bar2';
-		tree.stopMutationTracking();
-		expect(tree.pathDependencies.foo.length).toBe(1);
-		expect(tree.pathDependencies.bar.length).toBe(1);
-	});
-	test('should be able to remove listener', () => {
-		const tree = new ProxyStateTree({
-			foo: 'bar',
-			bar: 'baz'
-		});
-		const state = tree.get();
-		function render() {
-			tree.startPathsTracking();
-			if (state.foo === 'bar') {
-			} else {
-				state.bar;
-			}
-			return tree.stopPathsTracking();
-		}
-		const listener = tree.addMutationListener(render(), () => {
-			listener.dispose();
-		});
-		tree.startMutationTracking();
-		state.foo = 'bar2';
-		tree.stopMutationTracking();
-		expect(tree.pathDependencies).toEqual({});
-	});
+describe("REACTIONS", () => {
+  test("should be able to register a listener using paths", () => {
+    let reactionCount = 0;
+    const tree = new ProxyStateTree({
+      foo: "bar"
+    });
+    const tracker = tree.newTracker();
+    const state = tracker.get();
+    tracker.startPathsTracking();
+    state.foo; // eslint-disable-line
+    tracker.stopPathsTracking();
+    tracker.addMutationListener(() => {
+      reactionCount++;
+    });
+    tracker.startMutationTracking();
+    state.foo = "bar2";
+    tracker.stopMutationTracking();
+    expect(reactionCount).toBe(1);
+  });
+  test("should be able to update listener using paths", () => {
+    const tree = new ProxyStateTree({
+      foo: "bar",
+      bar: "baz"
+    });
+    const tracker = tree.newTracker();
+    const state = tracker.get();
+    function render() {
+      tracker.startPathsTracking();
+      if (state.foo === "bar") {
+      } else {
+        state.bar; // eslint-disable-line
+      }
+      tracker.stopPathsTracking();
+    }
+    render();
+    tracker.addMutationListener(() => {
+      render();
+    });
+    tracker.startMutationTracking();
+    state.foo = "bar2";
+    tracker.stopMutationTracking();
+    expect(tracker.paths.has("foo")).toBe(true);
+    expect(tracker.paths.has("bar")).toBe(true);
+  });
+  test("should be able to remove listener", () => {
+    const tree = new ProxyStateTree({
+      foo: "bar",
+      bar: "baz"
+    });
+    const tracker = tree.newTracker();
+    const state = tracker.get();
+    function render() {
+      tracker.startPathsTracking();
+      if (state.foo === "bar") {
+      } else {
+        state.bar; // eslint-disable-line
+      }
+      tracker.stopPathsTracking();
+    }
+    render();
+    const listener = tracker.addMutationListener(() => {
+      listener.dispose();
+    });
+    tracker.startMutationTracking();
+    state.foo = "bar2";
+    tracker.stopMutationTracking();
+    expect(tracker.listeners.size).toEqual(0);
+  });
+  test("should condense calls to mutation callback to one per paths group", () => {
+    let reactionCount = 0;
+    const tree = new ProxyStateTree({
+      items: [
+        {
+          title: "foo"
+        },
+        {
+          title: "bar"
+        }
+      ]
+    });
+    const tracker = tree.newTracker();
+    const state = tracker.get();
+    tracker.startPathsTracking();
+    state.items[0].title;// eslint-disable-line
+    state.items[1].title;// eslint-disable-line
+    tracker.stopPathsTracking();
+
+    tracker.addMutationListener(() => {
+      reactionCount++;
+    });
+    tracker.startMutationTracking();
+    state.items[0].title = "foo1";
+    state.items[1].title = "bar1";
+    tracker.stopMutationTracking();
+    expect(reactionCount).toBe(1);
+  });
 });
 
-describe('ITERATIONS', () => {
-	test('should track paths when using array iteration methods', () => {
-		const tree = new ProxyStateTree({
-			items: [
-				{
-					title: 'foo'
-				},
-				{
-					title: 'bar'
-				}
-			]
-		});
-		const state = tree.get();
-		tree.startPathsTracking();
-		state.items.forEach((item) => {
-			item.title;
-		});
-		const paths = tree.stopPathsTracking();
-		expect(paths).toEqual([ 'items', 'items.0', 'items.0.title', 'items.1', 'items.1.title' ]);
-	});
-	test('should track paths when using Object.keys', () => {
-		const tree = new ProxyStateTree({
-			items: {
-				foo: 'bar',
-				bar: 'baz'
-			}
-		});
-		const state = tree.get();
-		tree.startPathsTracking();
-		Object.keys(state.items).forEach((key) => {
-			state.items[key];
-		});
-		const paths = tree.stopPathsTracking();
-		expect(paths).toEqual([ 'items', 'items.foo', 'items.bar' ]);
-	});
-	test('should react to array mutation methods', () => {
-		let reactionCount = 0;
-		const tree = new ProxyStateTree({
-			items: [
-				{
-					title: 'foo'
-				},
-				{
-					title: 'bar'
-				}
-			]
-		});
-		const state = tree.get();
-		tree.startPathsTracking();
-		state.items.map((item) => item.title);
-		const paths = tree.stopPathsTracking();
-		expect(paths).toEqual([ 'items', 'items.0', 'items.0.title', 'items.1', 'items.1.title' ]);
-		tree.addMutationListener(paths, () => {
-			reactionCount++;
-		});
-		tree.startMutationTracking();
-		state.items.push({
-			title: 'mip'
-		});
-		tree.stopMutationTracking();
-		expect(reactionCount).toBe(1);
-	});
+describe("ITERATIONS", () => {
+  test("should track paths when using array iteration methods", () => {
+    const tree = new ProxyStateTree({
+      items: [
+        {
+          title: "foo"
+        },
+        {
+          title: "bar"
+        }
+      ]
+    });
+    const tracker = tree.newTracker();
+    const state = tracker.get();
+    tracker.startPathsTracking();
+    state.items.forEach(item => {
+      item.title;// eslint-disable-line
+    });
+    const paths = tracker.stopPathsTracking();
+    expect(paths).toEqual([
+      "items",
+      "items.0",
+      "items.0.title",
+      "items.1",
+      "items.1.title"
+    ]);
+  });
+  test("should track paths when using Object.keys", () => {
+    const tree = new ProxyStateTree({
+      items: {
+        foo: "bar",
+        bar: "baz"
+      }
+    });
+    const tracker = tree.newTracker();
+    const state = tracker.get();
+    tracker.startPathsTracking();
+    Object.keys(state.items).forEach(key => {
+      state.items[key]; // eslint-disable-line
+    });
+    const paths = tracker.stopPathsTracking();
+    expect(paths).toEqual(["items", "items.foo", "items.bar"]);
+  });
+  test("should react to array mutation methods", () => {
+    let reactionCount = 0;
+    const tree = new ProxyStateTree({
+      items: [
+        {
+          title: "foo"
+        },
+        {
+          title: "bar"
+        }
+      ]
+    });
+    const tracker = tree.newTracker();
+    const state = tracker.get();
+    tracker.startPathsTracking();
+    state.items.map(item => item.title);
+    const paths = tracker.stopPathsTracking();
+    expect(paths).toEqual([
+      "items",
+      "items.0",
+      "items.0.title",
+      "items.1",
+      "items.1.title"
+    ]);
+    tracker.addMutationListener(() => {
+      reactionCount++;
+    });
+    tracker.startMutationTracking();
+    state.items.push({
+      title: "mip"
+    });
+    tracker.stopMutationTracking();
+    expect(reactionCount).toBe(1);
+  });
 });

--- a/src/proxify.js
+++ b/src/proxify.js
@@ -1,110 +1,141 @@
-import isPlainObject from 'is-plain-object';
-
-const IS_PROXY = Symbol('IS_PROXY');
+import isPlainObject from "is-plain-object";
+const IS_PROXY = Symbol("IS_PROXY");
 
 function concat(path, prop) {
-	return path === undefined ? prop : path + '.' + prop;
+  return path === undefined ? prop : path + "." + prop;
 }
 
-const arrayMutations = new Set([ 'push', 'shift', 'pop', 'unshift', 'splice' ]);
-
-function createArrayProxy(tree, value, path) {
-	return new Proxy(value, {
-		get(target, prop) {
-			if (prop === IS_PROXY) return true;
-
-			if (prop === 'length' || (typeof target[prop] === 'function' && !arrayMutations.has(prop))) {
-				return target[prop];
-			}
-
-			const nestedPath = concat(path, prop);
-
-			if (tree.isTrackingPaths) {
-				tree.paths.add(nestedPath);
-			}
-
-			if (arrayMutations.has(prop)) {
-				if (!tree.isTrackingMutations) {
-					throw new Error(
-						`proxy-state-tree - You are mutating the path "${nestedPath}", but it is not allowed`
-					);
-				}
-				return (...args) => {
-					tree.mutations.push({
-						method: prop,
-						path: path,
-						args: args
-					});
-
-					return target[prop](...args);
-				};
-			}
-
-			return (target[prop] = proxify(tree, target[prop], nestedPath));
-		}
-	});
+function shouldTrackMutation(tracking, path) {
+  const trackMutation =
+    tracking.isTrackingMutations &&
+    ((!tracking.mutated && tracking.paths.has(path)) || tracking.devMode);
+  return trackMutation;
 }
 
-function createObjectProxy(tree, value, path) {
-	return new Proxy(value, {
-		get(target, prop) {
-			if (prop === IS_PROXY) return true;
+function createObjectProxy(tracking, value, currentPath) {
+  return new Proxy(value, {
+    get(target, prop) {
+      if (prop === IS_PROXY) return true;
 
-			const value = target[prop];
-			const nestedPath = concat(path, prop);
+      const value = target[prop];
+      const nestedPath = concat(currentPath, prop);
 
-			if (tree.isTrackingPaths) {
-				tree.paths.add(nestedPath);
-			}
+      tracking.isTrackingPaths && tracking.paths.add(nestedPath);
 
-			if (typeof value === 'function') {
-				return value(tree, nestedPath);
-			}
+      if (typeof value === "function") {
+        return value(tracking, nestedPath);
+      }
 
-			return (target[prop] = proxify(tree, value, nestedPath));
-		},
-		set(target, prop, value) {
-			const nestedPath = concat(path, prop);
+      return proxify(tracking, value, nestedPath);
+    },
+    set(target, prop, value) {
+      const nestedPath = concat(currentPath, prop);
 
-			if (!tree.isTrackingMutations) {
-				throw new Error(`proxy-state-tree - You are mutating the path "${nestedPath}", but it is not allowed`);
-			}
-			tree.mutations.push({
-				method: 'set',
-				path: nestedPath,
-				args: [ value ]
-			});
 
-			return (target[prop] = value);
-		},
-		deleteProperty(target, prop) {
-			const nestedPath = concat(path, prop);
-
-			tree.mutations.push({
-				method: 'unset',
-				path: nestedPath,
-				args: []
-			});
-
-			delete target[prop];
-
-			return true;
-		}
-	});
+      if (!tracking.isTrackingMutations) {
+        throw new Error(
+          `proxy-state-tree - You are mutating the path "${nestedPath}", but it is not allowed`
+        );
+      }
+      if (shouldTrackMutation(tracking, nestedPath)) {
+        tracking.mutated = true;
+        tracking.mutations.push({
+          method: "set",
+          path: nestedPath,
+          args: [value]
+        });
+      }
+      return (target[prop] = value);
+    },
+    deleteProperty(target, prop) {
+      const nestedPath = concat(currentPath, prop);
+      if (shouldTrackMutation(tracking, nestedPath)) {
+        tracking.mutated = true;
+        tracking.mutations.push({
+          method: "unset",
+          path: nestedPath,
+          args: []
+        });
+        return delete target[prop];
+      }
+    }
+  });
 }
 
-function proxify(tree, value, path) {
-	if (value) {
-		if (value[IS_PROXY]) {
-			return value;
-		} else if (Array.isArray(value)) {
-			return createArrayProxy(tree, value, path);
-		} else if (isPlainObject(value)) {
-			return createObjectProxy(tree, value, path);
-		}
-	}
-	return value;
+const arrayMutations = new Set(["push", "shift", "pop", "unshift", "splice"]);
+
+function createArrayProxy(tracking, value, currentPath) {
+  return new Proxy(value, {
+    get(target, prop) {
+      if (prop === IS_PROXY) return true;
+      if (
+        prop === "length" ||
+        (typeof target[prop] === "function" && !arrayMutations.has(prop))
+      ) {
+        return target[prop];
+      }
+
+      const nestedPath = concat(currentPath, prop);
+
+      tracking.isTrackingPaths && tracking.paths.add(nestedPath);
+
+      if (
+        shouldTrackMutation(tracking, currentPath) &&
+        arrayMutations.has(prop)
+      ) {
+        return (...args) => {
+          tracking.mutated = true;
+          tracking.mutations.push({
+            method: prop,
+            path: currentPath,
+            args: args
+          });
+          return target[prop](...args);
+        };
+      }
+
+      return proxify(tracking, target[prop], nestedPath);
+    },
+    set(target, prop, value) {
+      const nestedPath = concat(currentPath, prop);
+
+      if (!tracking.isTrackingMutations) {
+        throw new Error(
+          `proxy-state-tree - You are mutating the path "${nestedPath}", but it is not allowed`
+        );
+      }
+
+      if (shouldTrackMutation(tracking, nestedPath)) {
+        tracking.mutated = true;
+        tracking.mutations.push({
+          method: "set",
+          path: nestedPath,
+          args: [value]
+        });
+      }
+
+      return (target[prop] = value);
+    }
+  });
 }
 
 export { IS_PROXY };
-export default proxify;
+
+export default function proxify(tracking, value, currentPath) {
+  if (value) {
+    if (tracking.cache.has(value)) return tracking.cache.get(value);
+
+    let proxy;
+    if (Array.isArray(value)) {
+      proxy = createArrayProxy(tracking, value, currentPath);
+    } else if (isPlainObject(value)) {
+      proxy = createObjectProxy(tracking, value, currentPath);
+    }
+
+    if (proxy) {
+      tracking.cache.set(value, proxy);
+      return proxy;
+    }
+  }
+  return value;
+}


### PR DESCRIPTION
As discussed on discord. Here is my proposed solution for a nicer tracking API. Starting with an example:

```js 
import ProxyStateTree from "proxy-state-tree";

const tree = new ProxyStateTree(
  {
    foo: "bar",
    bar: ["foo"]
  },
  true // true for dev mode
);

const tracker = tree.newTracker();
const state = tracker.get();

function render() {
  tracker.startPathsTracking();
  const foo = state.foo;
  const bar = state.bar;
  tracker.stopPathsTracking();

  console.log(foo, bar[1]);
}

tracker.addMutationListener(() => {
  render();
});

render();

tracker.startMutationTracking();
state.foo = "bar2";
state.bar.push("baz");

console.log(JSON.stringify(tracker.stopMutationTracking(), null, 2));
// In DevMode:
// [
//   {
//     "method": "set",
//     "path": "foo",
//     "args": [
//       "bar2"
//     ]
//   },
//   {
//     "method": "push",// this entry is only there in dev mode
//     "path": "bar",
//     "args": [
//       "baz"
//     ]
//   }
// ]

```

Some implementation decisions: 
  * The user supplied state is *never* changed
       * Proxies are cached, per Tracker, using a `WeakMap` 
  * Each Tracker is keeping a map of tracked paths as a `Set`
  * All mutations are only tracked in `devMode`
        * Otherwise only the first mutation is recorded 

So for each component we would need to create a new `Tracker` that would than get one or more mutation listeners. This way if a component is removed the `Tracker` can  be removed to and all referenced proxies will disappear too. 