### PR TITLE
nested paths tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "proxy-state-tree",
-	"version": "1.0.0-alpha5",
+	"version": "1.0.0-alpha6",
 	"description": "An implementation of the Mobx/Vue state tracking approach, for library authors",
 	"main": "dist/proxy-state-tree.cjs.js",
 	"jsnext:main": "dist/proxy-state-tree.es.js",

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ class ProxyStateTree {
     this.state = state;
     this.pathDependencies = {};
     this.mutations = [];
-    this.paths = new Set();
+    this.paths = [];
     this.isTrackingPaths = false;
     this.isTrackingMutations = false;
     this.proxy = proxify(this, state);
@@ -32,7 +32,7 @@ class ProxyStateTree {
     }
     pathCallbacksCalled.length = 0;
   }
-  startMutationTracking() {
+  setMutationTracking() {
     const currentMutations = this.mutations.slice();
 
     this.isTrackingMutations = true;
@@ -40,20 +40,31 @@ class ProxyStateTree {
 
     return currentMutations;
   }
-  stopMutationTracking() {
+  clearMutationTracking() {
     this.isTrackingMutations = false;
 
     return this.mutations;
   }
-  startPathsTracking() {
+  setPathsTracking() {
     this.isTrackingPaths = true;
-    const currentPaths = Array.from(this.paths);
-    this.paths.clear();
-    return currentPaths;
+
+    return this.paths.push(new Set()) - 1;
   }
-  stopPathsTracking() {
-    this.isTrackingPaths = false;
-    return Array.from(this.paths);
+  clearPathsTracking(index) {
+    if (index !== this.paths.length - 1) {
+      throw new Error(
+        "Nested path tracking requires you to stop the nested path tracker before the outer"
+      );
+    }
+    const pathSet = this.paths[index];
+    const paths = Array.from(pathSet);
+    this.paths.pop();
+
+    if (!this.paths.length) {
+      this.isTrackingPaths = false;
+    }
+
+    return paths;
   }
   addMutationListener(initialPaths, cb) {
     const pathDependencies = this.pathDependencies;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -50,9 +50,9 @@ describe("OBJECTS", () => {
         }
       };
       const tree = new ProxyStateTree(state);
-      tree.startPathsTracking();
+      const trackId = tree.setPathsTracking();
       expect(tree.get().foo.bar).toBe("baz");
-      const paths = tree.stopPathsTracking();
+      const paths = tree.clearPathsTracking(trackId);
       expect(paths).toEqual(["foo", "foo.bar"]);
     });
   });
@@ -71,9 +71,9 @@ describe("OBJECTS", () => {
         foo: "bar"
       };
       const tree = new ProxyStateTree(state);
-      tree.startMutationTracking();
+      tree.setMutationTracking();
       tree.get().foo = "bar2";
-      const mutations = tree.stopMutationTracking();
+      const mutations = tree.clearMutationTracking();
       expect(mutations).toEqual([
         {
           method: "set",
@@ -88,9 +88,9 @@ describe("OBJECTS", () => {
         foo: "bar"
       };
       const tree = new ProxyStateTree(state);
-      tree.startMutationTracking();
+      tree.setMutationTracking();
       delete tree.get().foo;
-      const mutations = tree.stopMutationTracking();
+      const mutations = tree.clearMutationTracking();
       expect(mutations).toEqual([
         {
           method: "unset",
@@ -125,10 +125,30 @@ describe("ARRAYS", () => {
         foo: ["bar"]
       };
       const tree = new ProxyStateTree(state);
-      tree.startPathsTracking();
+      const trackId = tree.setPathsTracking();
       expect(tree.get().foo[0]).toBe("bar");
-      const paths = tree.stopPathsTracking();
+      const paths = tree.clearPathsTracking(trackId);
       expect(paths).toEqual(["foo", "foo.0"]);
+    });
+    test("should allow nested tracking", () => {
+      const tree = new ProxyStateTree({
+        foo: [
+          {
+            title: "foo"
+          }
+        ]
+      });
+
+      const state = tree.get();
+      const trackIdA = tree.setPathsTracking();
+      state.foo.map(item => {
+        const trackIdB = tree.setPathsTracking();
+        item.title; // eslint-disable-line
+        const pathsB = tree.clearPathsTracking(trackIdB);
+        expect(pathsB).toEqual(["foo.0.title"]);
+      });
+      const pathsA = tree.clearPathsTracking(trackIdA);
+      expect(pathsA).toEqual(["foo", "foo.0"]);
     });
   });
 
@@ -147,9 +167,9 @@ describe("ARRAYS", () => {
         foo: []
       };
       const tree = new ProxyStateTree(state);
-      tree.startMutationTracking();
+      tree.setMutationTracking();
       tree.get().foo.push("bar");
-      const mutations = tree.stopMutationTracking();
+      const mutations = tree.clearMutationTracking();
       expect(mutations).toEqual([
         {
           method: "push",
@@ -166,9 +186,9 @@ describe("ARRAYS", () => {
         foo: ["foo"]
       };
       const tree = new ProxyStateTree(state);
-      tree.startMutationTracking();
+      tree.setMutationTracking();
       tree.get().foo.pop();
-      const mutations = tree.stopMutationTracking();
+      const mutations = tree.clearMutationTracking();
       expect(mutations).toEqual([
         {
           method: "pop",
@@ -184,9 +204,9 @@ describe("ARRAYS", () => {
         foo: ["foo"]
       };
       const tree = new ProxyStateTree(state);
-      tree.startMutationTracking();
+      tree.setMutationTracking();
       tree.get().foo.shift();
-      const mutations = tree.stopMutationTracking();
+      const mutations = tree.clearMutationTracking();
       expect(mutations).toEqual([
         {
           method: "shift",
@@ -202,9 +222,9 @@ describe("ARRAYS", () => {
         foo: []
       };
       const tree = new ProxyStateTree(state);
-      tree.startMutationTracking();
+      tree.setMutationTracking();
       tree.get().foo.unshift("foo");
-      const mutations = tree.stopMutationTracking();
+      const mutations = tree.clearMutationTracking();
       expect(mutations).toEqual([
         {
           method: "unshift",
@@ -220,9 +240,9 @@ describe("ARRAYS", () => {
         foo: ["foo"]
       };
       const tree = new ProxyStateTree(state);
-      tree.startMutationTracking();
+      tree.setMutationTracking();
       tree.get().foo.splice(0, 1, "bar");
-      const mutations = tree.stopMutationTracking();
+      const mutations = tree.clearMutationTracking();
       expect(mutations).toEqual([
         {
           method: "splice",
@@ -267,15 +287,15 @@ describe("REACTIONS", () => {
       foo: "bar"
     });
     const state = tree.get();
-    tree.startPathsTracking();
+    const trackId = tree.setPathsTracking();
     state.foo; // eslint-disable-line
-    const paths = tree.stopPathsTracking();
+    const paths = tree.clearPathsTracking(trackId);
     tree.addMutationListener(paths, () => {
       reactionCount++;
     });
-    tree.startMutationTracking();
+    tree.setMutationTracking();
     state.foo = "bar2";
-    tree.stopMutationTracking();
+    tree.clearMutationTracking();
     tree.flush();
     expect(reactionCount).toBe(1);
   });
@@ -286,17 +306,17 @@ describe("REACTIONS", () => {
       bar: "baz"
     });
     const state = tree.get();
-    tree.startPathsTracking();
+    const trackId = tree.setPathsTracking();
     state.foo; // eslint-disable-line
     state.bar; // eslint-disable-line
-    const paths = tree.stopPathsTracking();
+    const paths = tree.clearPathsTracking(trackId);
     tree.addMutationListener(paths, () => {
       reactionCount++;
     });
-    tree.startMutationTracking();
+    tree.setMutationTracking();
     state.foo = "bar2";
     state.bar = "baz2";
-    tree.stopMutationTracking();
+    tree.clearMutationTracking();
     tree.flush();
     expect(reactionCount).toBe(1);
   });
@@ -307,19 +327,19 @@ describe("REACTIONS", () => {
     });
     const state = tree.get();
     function render() {
-      tree.startPathsTracking();
+      const trackId = tree.setPathsTracking();
       if (state.foo === "bar") {
       } else {
         state.bar; // eslint-disable-line
       }
-      return tree.stopPathsTracking();
+      return tree.clearPathsTracking(trackId);
     }
     const listener = tree.addMutationListener(render(), () => {
       listener.update(render());
     });
-    tree.startMutationTracking();
+    tree.setMutationTracking();
     state.foo = "bar2";
-    tree.stopMutationTracking();
+    tree.clearMutationTracking();
     tree.flush();
     expect(tree.pathDependencies.foo.length).toBe(1);
     expect(tree.pathDependencies.bar.length).toBe(1);
@@ -331,19 +351,19 @@ describe("REACTIONS", () => {
     });
     const state = tree.get();
     function render() {
-      tree.startPathsTracking();
+      const trackId = tree.setPathsTracking();
       if (state.foo === "bar") {
       } else {
         state.bar; // eslint-disable-line
       }
-      return tree.stopPathsTracking();
+      return tree.clearPathsTracking(trackId);
     }
     const listener = tree.addMutationListener(render(), () => {
       listener.dispose();
     });
-    tree.startMutationTracking();
+    tree.setMutationTracking();
     state.foo = "bar2";
-    tree.stopMutationTracking();
+    tree.clearMutationTracking();
     tree.flush();
     expect(tree.pathDependencies).toEqual({});
   });
@@ -362,11 +382,11 @@ describe("ITERATIONS", () => {
       ]
     });
     const state = tree.get();
-    tree.startPathsTracking();
+    const trackId = tree.setPathsTracking();
     state.items.forEach(item => {
       item.title; // eslint-disable-line 
     });
-    const paths = tree.stopPathsTracking();
+    const paths = tree.clearPathsTracking(trackId);
     expect(paths).toEqual([
       "items",
       "items.0",
@@ -383,11 +403,11 @@ describe("ITERATIONS", () => {
       }
     });
     const state = tree.get();
-    tree.startPathsTracking();
+    const trackId = tree.setPathsTracking();
     Object.keys(state.items).forEach(key => {
       state.items[key]; // eslint-disable-line
     });
-    const paths = tree.stopPathsTracking();
+    const paths = tree.clearPathsTracking(trackId);
     expect(paths).toEqual(["items", "items.foo", "items.bar"]);
   });
   test("should react to array mutation methods", () => {
@@ -403,9 +423,9 @@ describe("ITERATIONS", () => {
       ]
     });
     const state = tree.get();
-    tree.startPathsTracking();
+    const trackId = tree.setPathsTracking();
     state.items.map(item => item.title);
-    const paths = tree.stopPathsTracking();
+    const paths = tree.clearPathsTracking(trackId);
     expect(paths).toEqual([
       "items",
       "items.0",
@@ -416,11 +436,11 @@ describe("ITERATIONS", () => {
     tree.addMutationListener(paths, () => {
       reactionCount++;
     });
-    tree.startMutationTracking();
+    tree.setMutationTracking();
     state.items.push({
       title: "mip"
     });
-    tree.stopMutationTracking();
+    tree.clearMutationTracking();
     tree.flush();
     expect(reactionCount).toBe(1);
   });

--- a/src/proxify.js
+++ b/src/proxify.js
@@ -31,7 +31,7 @@ function createArrayProxy(tree, value, path) {
       const nestedPath = concat(path, prop);
 
       if (tree.isTrackingPaths) {
-        tree.paths.add(nestedPath);
+        tree.paths[tree.paths.length - 1].add(nestedPath);
       }
 
       if (arrayMutations.has(prop)) {
@@ -65,7 +65,7 @@ function createObjectProxy(tree, value, path) {
       const nestedPath = concat(path, prop);
 
       if (tree.isTrackingPaths) {
-        tree.paths.add(nestedPath);
+        tree.paths[tree.paths.length - 1].add(nestedPath);
       }
 
       if (typeof value === "function") {

--- a/src/proxify.js
+++ b/src/proxify.js
@@ -1,6 +1,11 @@
 import isPlainObject from "is-plain-object";
 
-const IS_PROXY = Symbol("IS_PROXY");
+export const IS_PROXY = Symbol("IS_PROXY");
+export const STATUS = {
+  IDLE: "IDLE",
+  TRACKING_PATHS: "TRACKING_PATHS",
+  TRACKING_MUTATIONS: "TRACKING_MUTATIONS"
+};
 
 function concat(path, prop) {
   return path === undefined ? prop : path + "." + prop;
@@ -30,12 +35,12 @@ function createArrayProxy(tree, value, path) {
 
       const nestedPath = concat(path, prop);
 
-      if (tree.isTrackingPaths) {
+      if (tree.status === STATUS.TRACKING_PATHS) {
         tree.paths[tree.paths.length - 1].add(nestedPath);
       }
 
       if (arrayMutations.has(prop)) {
-        if (!tree.isTrackingMutations) {
+        if (tree.status !== STATUS.TRACKING_MUTATIONS) {
           throw new Error(
             `proxy-state-tree - You are mutating the path "${nestedPath}", but it is not allowed`
           );
@@ -64,7 +69,7 @@ function createObjectProxy(tree, value, path) {
       const value = target[prop];
       const nestedPath = concat(path, prop);
 
-      if (tree.isTrackingPaths) {
+      if (tree.status === STATUS.TRACKING_PATHS) {
         tree.paths[tree.paths.length - 1].add(nestedPath);
       }
 
@@ -77,11 +82,12 @@ function createObjectProxy(tree, value, path) {
     set(target, prop, value) {
       const nestedPath = concat(path, prop);
 
-      if (!tree.isTrackingMutations) {
+      if (tree.status !== STATUS.TRACKING_MUTATIONS) {
         throw new Error(
           `proxy-state-tree - You are mutating the path "${nestedPath}", but it is not allowed`
         );
       }
+
       tree.mutations.push({
         method: "set",
         path: nestedPath,
@@ -92,6 +98,12 @@ function createObjectProxy(tree, value, path) {
     },
     deleteProperty(target, prop) {
       const nestedPath = concat(path, prop);
+
+      if (tree.status !== STATUS.TRACKING_MUTATIONS) {
+        throw new Error(
+          `proxy-state-tree - You are mutating the path "${nestedPath}", but it is not allowed`
+        );
+      }
 
       tree.mutations.push({
         method: "unset",
@@ -119,5 +131,4 @@ function proxify(tree, value, path) {
   return value;
 }
 
-export { IS_PROXY };
 export default proxify;


### PR DESCRIPTION
The API here is:

```js
test("should allow nested tracking", () => {
  const tree = new ProxyStateTree({
    foo: [
      {
        title: "foo"
      }
    ]
  });

  const state = tree.get();
  const trackIdA = tree.setPathsTracking();
  state.foo.map(item => {
    const trackIdB = tree.setPathsTracking();
    item.title; // eslint-disable-line
    const pathsB = tree.clearPathsTracking(trackIdB);
    expect(pathsB).toEqual(["foo.0.title"]);
  });
  const pathsA = tree.clearPathsTracking(trackIdA);
  expect(pathsA).toEqual(["foo", "foo.0"]);
});
```

Each tracker has its own `Set` stored in the `paths` array. New paths are added to the last item in the `paths` array, as that is the current tracker. When a tracker stops the array is popped and its paths is returned. If a previous tracker is stopped before the latest an error is thrown.

The API is now inspired by `setInterval` and `clearInterval`, which also is ID based (index).