### PR TITLE
dev/prod mode, only track mutations for observed paths in production

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 import proxify, { IS_PROXY, STATUS } from "./proxify";
 
 class ProxyStateTree {
-  constructor(state) {
+  constructor(state, options = { devmode: true }) {
     this.state = state;
+    this.options = options;
     this.pathDependencies = {};
     this.mutations = [];
     this.paths = [];


### PR DESCRIPTION
Introducing a second argument to the `ProxyStateTree` constructor as an options object like: 
```js
new ProxyStateTree({}, {devmode: false});
```

Currently the devmode defaults to `true` so nothing is changed for the current usage. But if proxy state tree is not in devmode only mutations of observed paths are tracked int the `mutations` array. 

No idea if this is actually necessary because having state in the tree that is not observed by anything isn't that common I think.  
